### PR TITLE
fix: anchor `last_raw_t` to now after warm start; raise `DEFAULT_SENSOR_MAX_GAP_S`

### DIFF
--- a/nilm_edge/src/refquery.py
+++ b/nilm_edge/src/refquery.py
@@ -548,10 +548,13 @@ class RefQueryDisaggregator:
                 j += 1
             self.window.push(float(last_val))
 
-        # Set schedule for subsequent live updates
-        self.last_raw_t = clean[-1][0]
+        # Anchor to now so that the first live _emit_model_samples call sees
+        # gap ≈ 0 and does not trigger a max_gap reset that would undo the
+        # warm start. Using clean[-1][0] (the last history timestamp) would
+        # cause gap = now - history_ts >> max_gap_s on the very next call.
+        self.last_raw_t = now_epoch
         self.last_raw_y = clean[-1][1]
-        self.next_model_t = grid[-1] + dt
+        self.next_model_t = now_epoch + dt
 
         # Mark that we have attempted warm start successfully (window full now)
         self._warm_attempted = True

--- a/nilm_edge/src/runtime_settings.py
+++ b/nilm_edge/src/runtime_settings.py
@@ -1,4 +1,6 @@
-DEFAULT_SENSOR_MAX_GAP_S = 60.0
+# Default is 5× the typical 60 s sensor poll interval so that minor asyncio
+# scheduling jitter or a single missed poll does not reset the ring buffer.
+DEFAULT_SENSOR_MAX_GAP_S = 300.0
 MIN_SENSOR_MAX_GAP_S = 1.0
 MAX_SENSOR_MAX_GAP_S = 3600.0
 


### PR DESCRIPTION
## Summary

Fixes two bugs that caused `_try_warm_start` to silently fail, leaving the ring buffer permanently cold and all appliance sensors at 0 W (closes #12, related to #11).

---

### Bug 1 — `_try_warm_start` immediately undoes itself

`_try_warm_start` fills the ring buffer correctly from HA history, then sets:

```python
# before
self.last_raw_t = clean[-1][0]  # last history timestamp — e.g. 2–40 min ago
self.next_model_t = grid[-1] + dt
```

The very next `_emit_model_samples(t=now, …)` call computes:

```
gap = now - last_raw_t  ≈  minutes  >>  max_gap_s (60 s)
```

This triggers `reset()`, discarding the just-filled window. Warm start silently fails on every restart.

**Fix:** anchor to `now_epoch` so the first live call sees gap ≈ 0:

```python
# after
self.last_raw_t = now_epoch
self.next_model_t = now_epoch + dt
```

---

### Bug 2 — `DEFAULT_SENSOR_MAX_GAP_S = 60.0` equals the typical poll interval

With a 60 s mains sensor, any asyncio scheduling jitter (60.001 s between polls due to system load or `await` overhead) exceeds `max_gap_s` and resets the ring buffer. Changed default from `60.0` → `300.0` (5× a typical 60 s poll interval), which tolerates missed polls and system load without affecting stale-sensor detection.

---

## Files changed

| File | Change |
|---|---|
| `nilm_edge/src/refquery.py` | `_try_warm_start`: anchor `last_raw_t` / `next_model_t` to `now_epoch` |
| `nilm_edge/src/runtime_settings.py` | `DEFAULT_SENSOR_MAX_GAP_S`: `60.0` → `300.0` |

## Testing

Verified on ha-nilm-edge 1.1.9, HAOS on Proxmox, mains sensor with 60 s update interval. After both fixes, `_try_warm_start` fills the window and the first live inference call succeeds — all four appliance entities appear in Home Assistant within ~2 minutes of container start.